### PR TITLE
make coffeescript a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+lib/shutdownHandler.js
 node_modules
 coverage

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,12 @@
-// Only require coffeescript if it is not already registered
-if (!require.extensions[".coffee"]) require("coffee-script/register");
+try {
+  module.exports = require("./shutdownHandler");
+} catch(e) {
+  if(e.message.startsWith("Cannot find module './shutdownHandler'")) {
+    // Only require coffeescript if it is not already registered
+    if (!require.extensions[".coffee"]) require("coffee-script/register");
 
-module.exports = require("./shutdownHandler.coffee");
+    module.exports = require("./shutdownHandler.coffee");
+  } else {
+    throw e;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,14 +19,15 @@
   "homepage": "https://github.com/UberEther/node-shutdown-events",
   "scripts": {
     "test": "mocha",
-    "test-cov": "istanbul cover --config test/istanbul.yml node_modules/mocha/bin/_mocha"
+    "test-cov": "istanbul cover --config test/istanbul.yml node_modules/mocha/bin/_mocha",
+    "prepublish": "coffee -o lib -c lib/*.coffee"
   },
   "dependencies": {
-    "coffee-script": "^1.9.2",
     "bluebird": "^2.9.13",
     "debug": "^2.2.0"
   },
   "devDependencies": {
+    "coffee-script": "^1.9.2",
     "mocha": "^2.3.0",
     "chai": "^3.2.0",
     "rewire": "^2.3.4",


### PR DESCRIPTION
Great little library! Making CoffeeScript a dev dependency will make it a lot easier for non CoffeeScript projects to use while still using CoffeeScript for development.

Of course you could also switch the load order, check and use CoffeeScript when available with fallback to loading precompiled when not available.

This should compile CoffeeScript on npm deploy and will default to using the compiled library when available.